### PR TITLE
Fix evaluate_predictions.py and improve PyTorch compatibility for predict_from_raw_data.py

### DIFF
--- a/nnunetv2/evaluation/evaluate_predictions.py
+++ b/nnunetv2/evaluation/evaluate_predictions.py
@@ -252,13 +252,4 @@ def evaluate_simple_entry_point():
 
 
 if __name__ == '__main__':
-    folder_ref = '/media/fabian/data/nnUNet_raw/Dataset004_Hippocampus/labelsTr'
-    folder_pred = '/home/fabian/results/nnUNet_remake/Dataset004_Hippocampus/nnUNetModule__nnUNetPlans__3d_fullres/fold_0/validation'
-    output_file = '/home/fabian/results/nnUNet_remake/Dataset004_Hippocampus/nnUNetModule__nnUNetPlans__3d_fullres/fold_0/validation/summary.json'
-    image_reader_writer = SimpleITKIO()
-    file_ending = '.nii.gz'
-    regions = labels_to_list_of_regions([1, 2])
-    ignore_label = None
-    num_processes = 12
-    compute_metrics_on_folder(folder_ref, folder_pred, output_file, image_reader_writer, file_ending, regions, ignore_label,
-                              num_processes)
+    evaluate_folder_entry_point()

--- a/nnunetv2/inference/predict_from_raw_data.py
+++ b/nnunetv2/inference/predict_from_raw_data.py
@@ -84,7 +84,8 @@ class nnUNetPredictor(object):
         for i, f in enumerate(use_folds):
             f = int(f) if f != 'all' else f
             checkpoint = torch.load(join(model_training_output_dir, f'fold_{f}', checkpoint_name),
-                                    map_location=torch.device('cpu'))
+                        map_location=torch.device('cpu'),
+                        weights_only=False)
             if i == 0:
                 trainer_name = checkpoint['trainer_name']
                 configuration_name = checkpoint['init_args']['configuration']


### PR DESCRIPTION
This pull request includes:
- Fixes to `evaluate_predictions.py` to align with updated folder structure and file references
- Adds explicit `weights_only=False` flag to `torch.load()` in `predict_from_raw_data.py` for compatibility with PyTorch >=2.6
- Verified changes locally on my fork with successful execution and metrics evaluation

Please review and let me know if any further changes are needed.
