### PR TITLE
Fix and Improve plot_network_architecture Using ONNX Export

### DIFF
--- a/nnunetv2/training/nnUNetTrainer/nnUNetTrainer.py
+++ b/nnunetv2/training/nnUNetTrainer/nnUNetTrainer.py
@@ -483,29 +483,31 @@ class nnUNetTrainer(object):
 
     def plot_network_architecture(self):
         if self._do_i_compile():
-        self.print_to_log_file("Skipping architecture plotting due to nnUNet_compile=True.")
-        return
+            self.print_to_log_file("Skipping architecture plotting due to nnUNet_compile=True.")
+            return
 
         if self.local_rank == 0:
-        try:
-            import torch
-            import os
-            dummy_input = torch.randn(1, self.num_input_channels, *self.configuration_manager.patch_size).to(self.device)
-            onnx_path = os.path.join(self.output_folder, "network_architecture.onnx")
-            torch.onnx.export(
-                self.network,
-                dummy_input,
-                onnx_path,
-                export_params=True,
-                opset_version=11,
-                do_constant_folding=True,
-                input_names=["input"],
-                output_names=["output"]
-            )
-            self.print_to_log_file(f"Network exported to ONNX format at: {onnx_path}", also_print_to_console=True)
-        except Exception as e:
-            self.print_to_log_file("Failed to export network to ONNX format.")
-            self.print_to_log_file(e, also_print_to_console=True)
+            try:
+                import torch
+                import os
+                dummy_input = torch.randn(1, self.num_input_channels, *self.configuration_manager.patch_size).to(self.device)
+                onnx_path = os.path.join(self.output_folder, "network_architecture.onnx")
+                torch.onnx.export(
+                    self.network,
+                    dummy_input,
+                    onnx_path,
+                    export_params=True,
+                    opset_version=11,
+                    do_constant_folding=True,
+                    input_names=["input"],
+                    output_names=["output"]
+                )
+                self.print_to_log_file(f"Network exported to ONNX format at: {onnx_path}", also_print_to_console=True)
+            except Exception as e:
+                self.print_to_log_file("Failed to export network to ONNX format.")
+                self.print_to_log_file(e, also_print_to_console=True)
+
+
 
     def do_split(self):
         """


### PR DESCRIPTION
### Fix and Improve plot_network_architecture Using ONNX Export
**Problem:**  The original plot_network_architecture() function uses the hiddenlayer library to generate a .pdf visualization of the model architecture:

`
import hiddenlayer as hl
g = hl.build_graph(...)
g.save(...)
`
**However, this method:** 

- Fails silently or throws exceptions in many environments, especially Google Colab.
- It is commented as “broken” in the current source code itself.

As a result, the model architecture is often not plotted at all, and users are left without any network diagram or export.

### **✅ Proposed Fix**
We propose replacing the broken visualization method with a clean and widely supported alternative using ONNX export, which saves the model in a .onnx format viewable with tools like [Netron](https://netron.app/).

**Here is the improved method:**

```
    def plot_network_architecture(self):
        if self._do_i_compile():
            self.print_to_log_file("Skipping architecture plotting due to nnUNet_compile=True.")
            return

        if self.local_rank == 0:
            try:
                import torch
                import os
                dummy_input = torch.randn(1, self.num_input_channels, *self.configuration_manager.patch_size).to(self.device)
                onnx_path = os.path.join(self.output_folder, "network_architecture.onnx")
                torch.onnx.export(
                    self.network,
                    dummy_input,
                    onnx_path,
                    export_params=True,
                    opset_version=11,
                    do_constant_folding=True,
                    input_names=["input"],
                    output_names=["output"]
                )
                self.print_to_log_file(f"Network exported to ONNX format at: {onnx_path}", also_print_to_console=True)
            except Exception as e:
                self.print_to_log_file("Failed to export network to ONNX format.")
                self.print_to_log_file(e, also_print_to_console=True)
```

---
### 🎯 Why ONNX?

- ONNX is officially supported by PyTorch and frequently maintained.
- Output .onnx files can be visualized interactively using [Netron](https://netron.app/), which is platform-independent and easy to use.
- This method avoids unnecessary dependencies and never blocks training, even if export fails.
- It is lightweight, stable, and extensible (can later include post-processing or hooks if needed).


**🧪 Installation (One-Time)**
To use this feature, the user only needs to install:
`!pip install onnx
`
No other libraries (like hiddenlayer, torchviz, or graphviz) are required anymore.

 **Final Note**
This change makes architecture export more robust, modern, and user-friendly without affecting existing functionality or requiring major refactoring.
If desired, the hiddenlayer fallback can be optionally retained behind a flag or environment variable.
We’d be happy to adjust the implementation to match project standards.

---
### EG: 
![image](https://github.com/user-attachments/assets/42e4f820-5d40-4d3c-b24e-06580befb15a)

